### PR TITLE
chore: load topology from Storage

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -66,8 +66,7 @@ func Run() error {
 
 	go health.StartHealthEndpoint(configuration.RelayerConfig.HealthPort)
 
-	// topologyProvider, err := topology.NewNetworkTopologyProvider(configuration.RelayerConfig.MpcConfig.TopologyConfiguration)
-	topologyProvider, err := topology.NewFixedNetworkTopologyProvider()
+	topologyProvider, err := topology.NewNetworkTopologyProvider(configuration.RelayerConfig.MpcConfig.TopologyConfiguration)
 	panicOnError(err)
 	topologyStore := topology.NewTopologyStore(configuration.RelayerConfig.MpcConfig.TopologyConfiguration.Path)
 	networkTopology, err := topologyStore.Topology()

--- a/ecs/task_definition-0_STAGE.json
+++ b/ecs/task_definition-0_STAGE.json
@@ -75,6 +75,10 @@
                 "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-0/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH"
             },
+            {
+                "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY",
+                "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-0/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY"
+            },
             { 
                 "name": "SYG_DOM_1",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-0/SYG_DOM_1"

--- a/ecs/task_definition-1_STAGE.json
+++ b/ecs/task_definition-1_STAGE.json
@@ -75,6 +75,10 @@
                 "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-1/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH"
             },
+            {
+                "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY",
+                "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-1/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY"
+            },
             { 
                 "name": "SYG_DOM_1",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-1/SYG_DOM_1"

--- a/ecs/task_definition-2_STAGE.json
+++ b/ecs/task_definition-2_STAGE.json
@@ -75,6 +75,10 @@
                 "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-2/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH"
             },
+            {
+                "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY",
+                "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-2/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY"
+            },
             { 
                 "name": "SYG_DOM_1",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-2/SYG_DOM_1"

--- a/ecs/task_definition-3_STAGE.json
+++ b/ecs/task_definition-3_STAGE.json
@@ -75,6 +75,10 @@
                 "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-3/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH"
             },
+            {
+                "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY",
+                "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-3/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY"
+            },
             { 
                 "name": "SYG_DOM_1",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-3/SYG_DOM_1"

--- a/ecs/task_definition-4_STAGE.json
+++ b/ecs/task_definition-4_STAGE.json
@@ -75,6 +75,10 @@
                 "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-4/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH"
             },
+            {
+                "name": "SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY",
+                "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-4/SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY"
+            },
             { 
                 "name": "SYG_DOM_1",
                 "valueFrom": "arn:aws:ssm:us-east-2:852551629426:parameter/chainbridge/relayers/relayer-4/SYG_DOM_1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For some time our deployment environment was using local network topology, now we are moving to topology that is saved on ChainSafe Storage.

Additionally, fix for missing ENV definition for the topology encryption key inside aws task definition.
