### PR TITLE
fix: increase max gas price allowed by default

### DIFF
--- a/chains/evm/config.go
+++ b/chains/evm/config.go
@@ -33,7 +33,7 @@ type RawEVMConfig struct {
 	chain.GeneralChainConfig `mapstructure:",squash"`
 	Bridge                   string          `mapstructure:"bridge"`
 	Handlers                 []HandlerConfig `mapstrcture:"handlers"`
-	MaxGasPrice              int64           `mapstructure:"maxGasPrice" default:"20000000000"`
+	MaxGasPrice              int64           `mapstructure:"maxGasPrice" default:"500000000000"`
 	GasMultiplier            float64         `mapstructure:"gasMultiplier" default:"1"`
 	GasLimit                 int64           `mapstructure:"gasLimit" default:"2000000"`
 	StartBlock               int64           `mapstructure:"startBlock"`

--- a/chains/evm/config_test.go
+++ b/chains/evm/config_test.go
@@ -79,7 +79,7 @@ func (s *NewEVMConfigTestSuite) Test_ValidConfig() {
 		},
 		Bridge:             "bridgeAddress",
 		GasLimit:           big.NewInt(2000000),
-		MaxGasPrice:        big.NewInt(20000000000),
+		MaxGasPrice:        big.NewInt(500000000000),
 		GasMultiplier:      big.NewFloat(1),
 		StartBlock:         big.NewInt(0),
 		BlockConfirmations: big.NewInt(10),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Set max gas price by default to be 500gwei. It won't be that much as it uses estimate gas price but that is the maximum.
If we want to change on mainnet it is easy to set it in the config.
All the other configurations seem reasonable.

Before it was 20 gwei and tx wouldn't appear on mumbai and goerli when the networks were congested.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #132 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
