### PR TITLE
fix: ignore extra networks from shared config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,6 @@ type RawConfig struct {
 // GetConfigFromENV reads config from ENV variables, validates it and parses
 // it into config suitable for application
 //
-//
 // Properties of RelayerConfig are expected to be defined as separate ENV variables
 // where ENV variable name reflects properties position in structure. Each ENV variable needs to be prefixed with SYG.
 //
@@ -98,23 +97,22 @@ func processRawConfig(rawConfig RawConfig, config *Config) (*Config, error) {
 		return config, err
 	}
 
+	chainConfigs := make([]map[string]interface{}, 0)
 	for i, chain := range rawConfig.ChainConfigs {
-		if i >= len(config.ChainConfigs) {
-			config.ChainConfigs = append(config.ChainConfigs, chain)
-		} else {
+		if i < len(config.ChainConfigs) {
 			err := mergo.Merge(&chain, config.ChainConfigs[i])
 			if err != nil {
 				return config, err
 			}
-
-			config.ChainConfigs[i] = chain
 		}
 
 		if chain["type"] == "" || chain["type"] == nil {
 			return config, fmt.Errorf("chain 'type' must be provided for every configured chain")
 		}
+		chainConfigs = append(chainConfigs, chain)
 	}
 
+	config.ChainConfigs = chainConfigs
 	config.RelayerConfig = relayerConfig
 	return config, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, if shared config has extra networks it appends it in its incomplete state. 
This PR only allows for networks that are actually configured in the env or file.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
