### PR TITLE
feat: mainnet deployment pipeline with release tags

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -11,6 +11,10 @@ on:
         required: true
         default: 'stable' 
         type: string
+      TOKEN: 
+        description: 'Authentication token'
+        required: true
+        type: string
 
 
 env:
@@ -32,6 +36,18 @@ jobs:
       id-token: write
 
     steps:
+      - name: Authentication
+        id: auth
+        run: |
+          if [ "${{ secrets.AUTH_TOKEN }}" != "${{ github.event.inputs.TOKEN }}" ]; then
+            echo "Authentcation failed. Exiting..."
+            exit 1
+          fi
+      - name: Continue
+        if: steps.auth.outcome == 'success'
+        run: |
+          echo 'Authentication Succeeded!!!'
+
       - name: checkout the source code
         uses: actions/checkout@v3
 

--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -1,0 +1,70 @@
+# The Licensed Work is (c) 2022 Sygma
+# SPDX-License-Identifier: BUSL-1.1
+
+name: sygma mainnet
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'The Release tag Version'
+        required: true
+        default: 'stable' 
+        type: string
+
+
+env:
+  AWS_REGION: '${{ secrets.AWS_REGION }}'
+  ENVIRONMENT: 'MAINNET'
+  REGISTRY: 'ghcr.io'
+  AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        relayer_id: [0, 1, 2]
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: checkout the source code
+        uses: actions/checkout@v3
+
+      - name: checkout ecs repo
+        uses: actions/checkout@v3
+        with:
+          repository: sygmaprotocol/devops
+          token: ${{ secrets.GHCR_TOKEN }}
+
+      - name: render jinja2 templates to task definition json files
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: 'relayers/ecs/task_definition-${{ env.ENVIRONMENT }}.j2'
+          output_file: 'relayers/ecs/task_definition-${{ matrix.relayer_id }}_${{ env.ENVIRONMENT }}.json'
+          data_format: json
+          variables: |
+            relayerId=${{ matrix.relayer_id }}
+            awsAccountId=${{ env.AWS_MAINNET }}
+            awsRegion=${{ env.AWS_REGION }}
+            imageTag=${{ inputs.release_tag }}
+            awsEnv=${{ env.ENVIRONMENT }}
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_MAINNET }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: GithubActions
+
+      - name: deploy task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: 'relayers/ecs/task_definition-${{ matrix.relayer_id }}_${{ env.ENVIRONMENT }}.json'
+          service: 'relayer-${{ matrix.relayer_id }}-service-${{ env.ENVIRONMENT }}'
+          cluster: 'relayer-${{ env.ENVIRONMENT }}'
+          wait-for-service-stability: true


### PR DESCRIPTION

## Description
New Features: use Release tags from Testnet to deploy to mainnet.


## Related Issue Or Context
Expected: Proven Stable version from Testnet environment only should be deployed to mainnet.

This pipeline will not trigger automatically based on commits. It will be a deliberate manual trigger where a stable version image tag will be required as input. Before deployment, this input tag is rendered and substituted in the ecs Task_Definition file. If the input is not provided, the default image tag is 'stable', which will publish the last stable version. keep in mind that Testnet environment published two images with two different tag, v series and stable.


Closes: #<issue>
https://app.zenhub.com/workspaces/sygma-protocol-62f126a54b7d5a55203732f0/issues/gh/sygmaprotocol/devops-backlog/48

https://app.zenhub.com/workspaces/sygma-protocol-62f126a54b7d5a55203732f0/issues/gh/sygmaprotocol/devops-backlog/49

## How Has This Been Tested? Testing details.
No Effect on other changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist: