### PR TITLE
fix: invalid bully restart

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,7 +109,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromENV() {
 				PingBackOff:      1 * time.Second,
 				PingInterval:     1 * time.Second,
 				ElectionWaitTime: 2 * time.Second,
-				BullyWaitTime:    25 * time.Second,
+				BullyWaitTime:    3 * time.Minute,
 			},
 		},
 		ChainConfigs: []map[string]interface{}{
@@ -214,7 +214,7 @@ func (s *GetConfigTestSuite) Test_SharedConfigLengthMismatch() {
 				PingBackOff:      1 * time.Second,
 				PingInterval:     1 * time.Second,
 				ElectionWaitTime: 2 * time.Second,
-				BullyWaitTime:    25 * time.Second,
+				BullyWaitTime:    3 * time.Minute,
 			},
 		},
 		ChainConfigs: []map[string]interface{}{
@@ -411,7 +411,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 						PingBackOff:      1 * time.Second,
 						PingInterval:     1 * time.Second,
 						ElectionWaitTime: 2 * time.Second,
-						BullyWaitTime:    25 * time.Second,
+						BullyWaitTime:    3 * time.Minute,
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{

--- a/config/relayer/config.go
+++ b/config/relayer/config.go
@@ -67,7 +67,7 @@ type RawBullyConfig struct {
 	PingBackOff      string `mapstructure:"PingBackOff" json:"pingBackOff" default:"1s"`
 	PingInterval     string `mapstructure:"PingInterval" json:"pingInterval" default:"1s"`
 	ElectionWaitTime string `mapstructure:"ElectionWaitTime" json:"electionWaitTime" default:"2s"`
-	BullyWaitTime    string `mapstructure:"BullyWaitTime" json:"bullyWaitTime" default:"25s"`
+	BullyWaitTime    string `mapstructure:"BullyWaitTime" json:"bullyWaitTime" default:"3m"`
 }
 
 func (c *RawRelayerConfig) Validate() error {

--- a/tss/coordinator.go
+++ b/tss/coordinator.go
@@ -298,6 +298,11 @@ func (c *Coordinator) waitForStart(
 		select {
 		case wMsg := <-msgChan:
 			{
+				if coordinator != "" && wMsg.From != coordinator {
+					log.Warn().Msgf("Received initate message from a peer %s that is not the coordinator %s", wMsg.From.Pretty(), coordinator.Pretty())
+					continue
+				}
+
 				coordinatorTimeoutTicker.Reset(timeout)
 
 				log.Debug().Str("SessionID", tssProcess.SessionID()).Msgf("sent ready message to %s", wMsg.From)
@@ -312,10 +317,8 @@ func (c *Coordinator) waitForStart(
 				// having startMsg.From as "" is special case when peer is not selected in subset
 				// but should wait for start message if existing singing process fails
 				if coordinator != "" && startMsg.From != coordinator {
-					return fmt.Errorf(
-						"start message received from peer %s that is not coordinator %s",
-						startMsg.From.Pretty(), coordinator.Pretty(),
-					)
+					log.Warn().Msgf("Received start message from a peer %s that is not the coordinator %s", startMsg.From.Pretty(), coordinator.Pretty())
+					continue
 				}
 
 				msg, err := common.UnmarshalStartMessage(startMsg.Payload)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The bully process can finish without all the relayers being in it and the next process then starts with invalid coordinators on some relayers because of it.

## Description
<!--- Describe your changes in detail -->
Increase bully wait time to possibly include more relayers and fix the process coordinator so messages from invalid coordinators cannot break the proccess.

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #226 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
