### PR TITLE
chore: slack notify

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -86,6 +86,15 @@ jobs:
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true
 
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
+
           ######################## region 3 ########################
   deploy_region_3:
     name: deploy
@@ -148,3 +157,12 @@ jobs:
           service: 'relayer-${{ matrix.relayer_id }}-service-${{ env.ENVIRONMENT }}'
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true      
+
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -14,6 +14,7 @@ env:
   REGISTRY: 'ghcr.io'
   TAG: 'latest'
 
+
 jobs:
   push:
     name: push
@@ -45,6 +46,15 @@ jobs:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}
+          
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
           
           ######################## region 1 ########################
   deploy_reg_1:
@@ -96,6 +106,15 @@ jobs:
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true
 
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
+
           ######################## region 2 ########################
   deploy_reg_2:
     needs: push
@@ -146,6 +165,15 @@ jobs:
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true
 
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
+
           ######################## region 3 ########################
   deploy_reg_3:
     needs: push
@@ -195,3 +223,12 @@ jobs:
           service: 'relayer-${{ matrix.relayer_id }}-service-${{ env.ENVIRONMENT }}'
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true
+
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()         

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -54,6 +54,15 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}
 
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
+
           ######################## region 1 ########################
   deploy:
     needs: push
@@ -103,6 +112,15 @@ jobs:
           service: 'relayer-${{ matrix.relayer_id }}-service-${{ env.ENVIRONMENT }}'
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true
+
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
 
           ######################## region 2 ########################
 
@@ -155,3 +173,12 @@ jobs:
           service: 'relayer-${{ matrix.relayer_id }}-service-${{ env.ENVIRONMENT }}'
           cluster: 'relayer-${{ env.ENVIRONMENT }}'
           wait-for-service-stability: true
+
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()


### PR DESCRIPTION

![Screenshot 2024-01-31 at 12 03 12 AM](https://github.com/sygmaprotocol/sygma-relayer/assets/58168886/b4960f74-17eb-4fb3-b9c9-57784b8d600e)
Pipeline Status Notification to be delivered to Slack Channel

## Description
Modified Github Actions pipeline to send the status to a slack channel. Thus remind the user if the deployment or CI i.e build image failed or successful. 
![Screenshot 2024-01-30 at 11 55 48 PM](https://github.com/sygmaprotocol/sygma-relayer/assets/58168886/d40e4a5d-f7cd-4c30-a179-91647048e285)

## Related Issue Or Context
Related: #300

## How Has This Been Tested? Testing details.
See the attachment ![Screenshot 2024-01-30 at 11 55 48 PM](https://github.com/sygmaprotocol/sygma-relayer/assets/58168886/d40e4a5d-f7cd-4c30-a179-91647048e285)

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)

