### PR TITLE
chore: workflow  renaming

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -1,7 +1,7 @@
 # The Licensed Work is (c) 2022 Sygma
 # SPDX-License-Identifier: BUSL-1.1
 
-name: sygma mainnet
+name: Sygma Mainnet
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -1,7 +1,7 @@
 # The Licensed Work is (c) 2022 Sygma
 # SPDX-License-Identifier: LGPL-3.0-only
 
-name: sygma/deploy/stage
+name: Sygma Devnet
 
 on:
   push:

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -1,7 +1,7 @@
 # The Licensed Work is (c) 2022 Sygma
 # SPDX-License-Identifier: LGPL-3.0-only
 
-name: sygma/deploy/testnet
+name: Sygma Testnet
 
 on:
   release:


### PR DESCRIPTION
Workflow renaming 

## Description
Changing the workflow names to display as follows

- Sygma Devnet
- Sygma Tesntet
- Sygma Mainnet

instead of displaying as Sygma/Deploy/stage

With this change, it will be easy to recognise the pipeline. e.g as Sygm Devnet from `sygma-notifs` slack channel  instead of Sygma/Deploy/stage

## Related Issue Or Context
Related: #300
