### PR TITLE
chore: remove stable tag for image version

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -9,7 +9,6 @@ on:
       release_tag:
         description: 'The Release tag Version'
         required: true
-        default: 'stable' 
         type: string
       TOKEN: 
         description: 'Authentication token'


### PR DESCRIPTION
## Description
Remove stable tag version as default to prevent deploying Testnet code into mainnet.

## Types of changes
- [ x] Breaking change (fix or feature that would cause existing functionality to change)


