### PR TITLE
fix: add fee estimate when calculating btc inputs

### DIFF
--- a/chains/btc/executor/executor.go
+++ b/chains/btc/executor/executor.go
@@ -202,7 +202,11 @@ func (e *Executor) rawTx(proposals []*BtcTransferProposal, resource config.Resou
 	if err != nil {
 		return nil, nil, err
 	}
-	inputAmount, utxos, err := e.inputs(tx, resource.Address, outputAmount)
+	feeEstimate, err := e.fee(int64(len(proposals)), int64(len(proposals)))
+	if err != nil {
+		return nil, nil, err
+	}
+	inputAmount, utxos, err := e.inputs(tx, resource.Address, outputAmount+feeEstimate)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Calculate btc inputs with fee estimate when the assumption is the transaction will have at least
as many inputs as outputs.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: https://www.notion.so/veridise/Transactions-blocked-for-low-fees-97816122a11a4604b980fe38cbc5b19e

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
