### PR TITLE
fix: handle msg.To being empty properly

### DIFF
--- a/tss/frost/common/base.go
+++ b/tss/frost/common/base.go
@@ -108,7 +108,7 @@ func (k *BaseFrostTss) BroadcastPeers(msg *protocol.Message) ([]peer.ID, error) 
 		return k.Peers, nil
 	} else {
 		if string(msg.To) == "" {
-			return []peer.ID{}, nil
+			return k.Peers, nil
 		}
 
 		p, err := peer.Decode(string(msg.To))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Msg.To when is empty and it is not a broadcast is an error message which should be propagated to all.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: https://www.notion.so/veridise/Incorrectly-handling-empty-msg-To-5be517d2eead4994bbdfdb6206ab2078

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
