### PR TITLE
fix: reduce tx nonce collision chances

### DIFF
--- a/chains/btc/listener/event-handlers_test.go
+++ b/chains/btc/listener/event-handlers_test.go
@@ -67,19 +67,11 @@ func (s *DepositHandlerTestSuite) Test_FetchDepositFails_GetBlockVerboseTxError(
 	s.NotNil(err)
 }
 
-func (s *DepositHandlerTestSuite) Test_CalculateNonceFail_BlockNumberOverflow() {
-
-	blockNumber := new(big.Int)
-	blockNumber.SetString("18446744073709551616", 10)
-	nonce, err := s.fungibleTransferEventHandler.CalculateNonce(blockNumber, 5)
-	s.Equal(nonce, uint64(0))
-	s.NotNil(err)
-}
-
 func (s *DepositHandlerTestSuite) Test_CalculateNonce() {
-	blockNumber := big.NewInt(123)
-	nonce, err := s.fungibleTransferEventHandler.CalculateNonce(blockNumber, 4)
-	s.Equal(nonce, uint64(1234))
+	blockNumber := big.NewInt(850000)
+	nonce, err := s.fungibleTransferEventHandler.CalculateNonce(blockNumber, "a3f1e4d8b3c5e2a1f6d3c7e4b8a9f3e2c1d4a6b7c8e3f1d2c4b5a6e7")
+	fmt.Println(nonce)
+	s.Equal(nonce, uint64(12849897320021645821))
 	s.Nil(err)
 }
 

--- a/chains/btc/listener/event-handlers_test.go
+++ b/chains/btc/listener/event-handlers_test.go
@@ -78,7 +78,7 @@ func (s *DepositHandlerTestSuite) Test_CalculateNonce() {
 func (s *DepositHandlerTestSuite) Test_HandleDepositFails_ExecutionContinue() {
 	blockNumber := big.NewInt(100)
 	data2 := map[string]any{
-		"deposit_nonce": uint64(1001),
+		"deposit_nonce": uint64(8228687738678474667),
 		"resource_id":   [32]byte{0},
 		"amount":        big.NewInt(19000),
 		"deposit_data":  "0xe9f23A8289764280697a03aC06795eA92a170e42_1",


### PR DESCRIPTION
reduce tx nonce collision chances
## Description
Update the CalculateNonce function algorithm to generate a uint64 nonce by concatenating the string representations of a given block number and transaction hash, hashing the concatenated string using SHA-256, and folding the hash into a uint64 value through XOR operations.
## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: https://veridise.notion.site/Possible-transaction-nonce-collision-ddbb77e582464199accd02c171bd5ed6

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
