### PR TITLE
fix: sort utxos by oldest to prevent mismatched messages

### DIFF
--- a/chains/btc/mempool/mempool.go
+++ b/chains/btc/mempool/mempool.go
@@ -8,10 +8,18 @@ import (
 	"sort"
 )
 
+type Status struct {
+	Confirmed   bool
+	BlockHeight uint64 `json:"block_height"`
+	BlockHash   string `json:"block_hash"`
+	BlockTime   uint64 `json:"block_time"`
+}
+
 type Utxo struct {
-	TxID  string `json:"txid"`
-	Vout  uint32 `json:"vout"`
-	Value uint64 `json:"value"`
+	TxID   string `json:"txid"`
+	Vout   uint32 `json:"vout"`
+	Value  uint64 `json:"value"`
+	Status Status `json:"status"`
 }
 
 type Fee struct {
@@ -69,7 +77,7 @@ func (a *MempoolAPI) Utxos(address string) ([]Utxo, error) {
 		return nil, err
 	}
 	sort.Slice(utxos, func(i int, j int) bool {
-		return utxos[i].TxID < utxos[j].TxID
+		return utxos[i].Status.BlockTime < utxos[j].Status.BlockTime
 	})
 
 	return utxos, nil

--- a/chains/btc/mempool/mempool_test.go
+++ b/chains/btc/mempool/mempool_test.go
@@ -52,12 +52,24 @@ func (s *MempoolTestSuite) Test_Utxo_SuccessfulFetch() {
 		{
 			TxID:  "28154e2008912d27978225c096c22ffe2ea65e1d55bf440ee41c21f9489c7fe1",
 			Vout:  0,
-			Value: 11198,
+			Value: 11197,
+			Status: mempool.Status{
+				Confirmed:   true,
+				BlockHeight: 2812826,
+				BlockHash:   "000000000000001a01d4058773384f2c23aed5a7e5ede252f99e290fa58324a3",
+				BlockTime:   1715083122,
+			},
 		},
 		{
 			TxID:  "28154e2008912d27978225c096c22ffe2ea65e1d55bf440ee41c21f9489c7fe9",
 			Vout:  0,
-			Value: 11197,
+			Value: 11198,
+			Status: mempool.Status{
+				Confirmed:   true,
+				BlockHeight: 2812827,
+				BlockHash:   "000000000000001a01d4058773384f2c23aed5a7e5ede252f99e290fa58324a5",
+				BlockTime:   1715083123,
+			},
 		},
 	})
 }

--- a/chains/btc/mempool/test-data/successful-utxo.json
+++ b/chains/btc/mempool/test-data/successful-utxo.json
@@ -1,4 +1,4 @@
 [
-    {"txid":"28154e2008912d27978225c096c22ffe2ea65e1d55bf440ee41c21f9489c7fe9","vout":0,"status":{"confirmed":true,"block_height":2812826,"block_hash":"000000000000001a01d4058773384f2c23aed5a7e5ede252f99e290fa58324a3","block_time":1715083122},"value":11197},
-    {"txid":"28154e2008912d27978225c096c22ffe2ea65e1d55bf440ee41c21f9489c7fe1","vout":0,"status":{"confirmed":true,"block_height":2812826,"block_hash":"000000000000001a01d4058773384f2c23aed5a7e5ede252f99e290fa58324a3","block_time":1715083122},"value":11198}
+    {"txid":"28154e2008912d27978225c096c22ffe2ea65e1d55bf440ee41c21f9489c7fe9","vout":0,"status":{"confirmed":true,"block_height":2812827,"block_hash":"000000000000001a01d4058773384f2c23aed5a7e5ede252f99e290fa58324a5","block_time":1715083123},"value":11198},
+    {"txid":"28154e2008912d27978225c096c22ffe2ea65e1d55bf440ee41c21f9489c7fe1","vout":0,"status":{"confirmed":true,"block_height":2812826,"block_hash":"000000000000001a01d4058773384f2c23aed5a7e5ede252f99e290fa58324a3","block_time":1715083122},"value":11197}
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sort utxos by oldest to mitigate issues when multiple relayers call the mempool at the same time and get different reuslts.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: https://veridise.notion.site/Dropped-mismatched-messages-122d4c72ddcb4460be658d28115a23e1
## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
