### PR TITLE
fix: schnorr signature hash missing leading zeroes

### DIFF
--- a/chains/btc/executor/executor.go
+++ b/chains/btc/executor/executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
@@ -163,15 +162,13 @@ func (e *Executor) executeResourceProps(props []*BtcTransferProposal, resource c
 	tssProcesses := make([]tss.TssProcess, len(tx.TxIn))
 	for i := range tx.TxIn {
 		sessionID := fmt.Sprintf("%s-%d", sessionID, i)
-		txHash, err := txscript.CalcTaprootSignatureHash(sigHashes, txscript.SigHashDefault, tx, i, prevOutputFetcher)
+		signingHash, err := txscript.CalcTaprootSignatureHash(sigHashes, txscript.SigHashDefault, tx, i, prevOutputFetcher)
 		if err != nil {
 			return err
 		}
-		msg := new(big.Int)
-		msg.SetBytes(txHash[:])
 		signing, err := signing.NewSigning(
 			i,
-			msg,
+			signingHash,
 			resource.Tweak,
 			messageID,
 			sessionID,

--- a/tss/frost/signing/signing_test.go
+++ b/tss/frost/signing/signing_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"testing"
 	"time"
 
@@ -50,8 +49,6 @@ func (s *SigningTestSuite) Test_ValidSigningProcess() {
 	s.Nil(err)
 
 	msgBytes := []byte("Message")
-	msg := big.NewInt(0)
-	msg.SetBytes(msgBytes)
 	for i, host := range s.Hosts {
 		communication := tsstest.TestCommunication{
 			Host:          host,
@@ -60,7 +57,7 @@ func (s *SigningTestSuite) Test_ValidSigningProcess() {
 		communicationMap[host.ID()] = &communication
 		fetcher := keyshare.NewFrostKeyshareStore(fmt.Sprintf("../../test/keyshares/%d-frost.keyshare", i))
 
-		signing, err := signing.NewSigning(1, msg, tweak, "signing1", "signing1", host, &communication, fetcher)
+		signing, err := signing.NewSigning(1, msgBytes, tweak, "signing1", "signing1", host, &communication, fetcher)
 		if err != nil {
 			panic(err)
 		}
@@ -85,8 +82,8 @@ func (s *SigningTestSuite) Test_ValidSigningProcess() {
 	sig2 := <-resultChn
 	tSig1 := sig1.(signing.Signature)
 	tSig2 := sig2.(signing.Signature)
-	s.Equal(tweakedKeyshare.PublicKey.Verify(tSig1.Signature, msg.Bytes()), true)
-	s.Equal(tweakedKeyshare.PublicKey.Verify(tSig2.Signature, msg.Bytes()), true)
+	s.Equal(tweakedKeyshare.PublicKey.Verify(tSig1.Signature, msgBytes), true)
+	s.Equal(tweakedKeyshare.PublicKey.Verify(tSig2.Signature, msgBytes), true)
 	cancel()
 	err = pool.Wait()
 	s.Nil(err)
@@ -105,8 +102,6 @@ func (s *SigningTestSuite) Test_MultipleProcesses() {
 	s.Nil(err)
 
 	msgBytes := []byte("Message")
-	msg := big.NewInt(0)
-	msg.SetBytes(msgBytes)
 	for i, host := range s.Hosts {
 		communication := tsstest.TestCommunication{
 			Host:          host,
@@ -115,15 +110,15 @@ func (s *SigningTestSuite) Test_MultipleProcesses() {
 		communicationMap[host.ID()] = &communication
 		fetcher := keyshare.NewFrostKeyshareStore(fmt.Sprintf("../../test/keyshares/%d-frost.keyshare", i))
 
-		signing1, err := signing.NewSigning(1, msg, tweak, "signing1", "signing1", host, &communication, fetcher)
+		signing1, err := signing.NewSigning(1, msgBytes, tweak, "signing1", "signing1", host, &communication, fetcher)
 		if err != nil {
 			panic(err)
 		}
-		signing2, err := signing.NewSigning(1, msg, tweak, "signing1", "signing2", host, &communication, fetcher)
+		signing2, err := signing.NewSigning(1, msgBytes, tweak, "signing1", "signing2", host, &communication, fetcher)
 		if err != nil {
 			panic(err)
 		}
-		signing3, err := signing.NewSigning(1, msg, tweak, "signing1", "signing3", host, &communication, fetcher)
+		signing3, err := signing.NewSigning(1, msgBytes, tweak, "signing1", "signing3", host, &communication, fetcher)
 		if err != nil {
 			panic(err)
 		}
@@ -173,8 +168,6 @@ func (s *SigningTestSuite) Test_ProcessTimeout() {
 	s.Nil(err)
 
 	msgBytes := []byte("Message")
-	msg := big.NewInt(0)
-	msg.SetBytes(msgBytes)
 	for i, host := range s.Hosts {
 		communication := tsstest.TestCommunication{
 			Host:          host,
@@ -183,7 +176,7 @@ func (s *SigningTestSuite) Test_ProcessTimeout() {
 		communicationMap[host.ID()] = &communication
 		fetcher := keyshare.NewFrostKeyshareStore(fmt.Sprintf("../../test/keyshares/%d-frost.keyshare", i))
 
-		signing, err := signing.NewSigning(1, msg, tweak, "signing1", "signing1", host, &communication, fetcher)
+		signing, err := signing.NewSigning(1, msgBytes, tweak, "signing1", "signing1", host, &communication, fetcher)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
*big.Int that ECDSA uses to pass messages removes leading zeroes which then construes a different hash than the Bitcoin node expects.
This changes everything to use []byte directly.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #340 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
