### PR TITLE
chore: Access Secrets based on specific environments

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
 
-run-name: Deploy Relayers to mainnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+run-name: Deploy Relayers to Mainnet - ${{ inputs.release_tag }} by @${{ github.actor }}
 
 env:
   ENVIRONMENT: 'MAINNET'

--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -15,20 +15,23 @@ on:
         required: true
         type: string
 
+run-name: Deploy Relayers to mainnet - ${{ inputs.release_tag }} by @${{ github.actor }}
 
 env:
   ENVIRONMENT: 'MAINNET'
   REGISTRY: 'ghcr.io'
-  AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
 
 jobs:
             ######################## region 1 ########################
   deploy_region_1:
     name: deploy
     runs-on: ubuntu-latest
+    environment: mainnet
     strategy:
       matrix:
         relayer_id: [0, 1]
+    env:
+      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
 
     permissions:
       contents: read
@@ -62,7 +65,7 @@ jobs:
           variables: |
             relayerId=${{ matrix.relayer_id }}
             awsAccountId=${{ env.AWS_MAINNET }}
-            awsRegion=${{ secrets.AWS_REGION }}
+            awsRegion=${{ secrets.AWS_REGION_1 }}
             imageTag=${{ inputs.release_tag }}
             awsEnv=${{ env.ENVIRONMENT }}
             awsEfs=${{ secrets.MAINNET_EFS_1 }}
@@ -71,7 +74,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_MAINNET }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION_1 }}
           role-session-name: GithubActions
 
       - name: deploy task definition
@@ -86,7 +89,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
         if: always()
@@ -95,9 +98,12 @@ jobs:
   deploy_region_3:
     name: deploy
     runs-on: ubuntu-latest
+    environment: mainnet
     strategy:
       matrix:
         relayer_id: [2]
+    env:
+      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
 
     permissions:
       contents: read
@@ -155,7 +161,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
         if: always()

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+run-name: Deploy Relayers to Devnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
   ENVIRONMENT: STAGE
   REGISTRY: 'ghcr.io'

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   ENVIRONMENT: STAGE
-  AWS_STAGE: '${{ secrets.AWS_ARN }}'
   REGISTRY: 'ghcr.io'
   TAG: 'latest'
 
@@ -61,10 +60,12 @@ jobs:
     needs: push
     name: deploy region 1
     runs-on: ubuntu-latest
+    environment: devnet
     strategy:
       matrix:
         relayer_id: [1]
-
+    env:
+      AWS_DEVNET: '${{ secrets.AWS_DEVNET }}'
     permissions:
       contents: read
       id-token: write
@@ -84,71 +85,15 @@ jobs:
           data_format: json
           variables: |
             relayerId=${{ matrix.relayer_id }}
-            awsAccountId=${{ env.AWS_STAGE }}
-            awsRegion=${{ secrets.AWS_REGION }}
+            awsAccountId=${{ env.AWS_DEVNET }}
+            awsRegion=${{ secrets.AWS_REGION_1 }}
             awsEfs=${{ secrets.DEVNET_EFS_1 }}
 
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_STAGE }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-session-name: GithubActions
-
-      - name: deploy task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: 'relayers/ecs/task_definition-${{ matrix.relayer_id }}_${{ env.ENVIRONMENT }}.json'
-          service: 'relayer-${{ matrix.relayer_id }}-service-${{ env.ENVIRONMENT }}'
-          cluster: 'relayer-${{ env.ENVIRONMENT }}'
-          wait-for-service-stability: true
-
-      - name: slack notify
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-        if: always()
-
-          ######################## region 2 ########################
-  deploy_reg_2:
-    needs: push
-    name: deploy region 2
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        relayer_id: [3]
-
-    permissions:
-      contents: read
-      id-token: write
-
-    steps: 
-      - name: checkout ecs repo
-        uses: actions/checkout@v3
-        with:
-          repository: sygmaprotocol/devops
-          token: ${{ secrets.GHCR_TOKEN }}
-
-      - name: render jinja2 templates to task definition json files
-        uses: cuchi/jinja2-action@v1.2.0
-        with:
-          template: 'relayers/ecs/task_definition-${{ env.ENVIRONMENT }}.j2'
-          output_file: 'relayers/ecs/task_definition-${{ matrix.relayer_id }}_${{ env.ENVIRONMENT }}.json'
-          data_format: json
-          variables: |
-            relayerId=${{ matrix.relayer_id }}
-            awsAccountId=${{ env.AWS_STAGE }}
-            awsRegion=${{ secrets.AWS_REGION_2 }}
-            awsEfs=${{ secrets.DEVNET_EFS_2 }}
-
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_STAGE }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
-          aws-region: ${{ secrets.AWS_REGION_2 }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_DEVNET }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
+          aws-region: ${{ secrets.AWS_REGION_1 }}
           role-session-name: GithubActions
 
       - name: deploy task definition
@@ -173,9 +118,13 @@ jobs:
     needs: push
     name: deploy region 3
     runs-on: ubuntu-latest
+    environment: devnet
     strategy:
       matrix:
         relayer_id: [4]
+
+    env: 
+      AWS_DEVNET: '${{ secrets.AWS_DEVNET }}'
 
     permissions:
       contents: read
@@ -196,14 +145,14 @@ jobs:
           data_format: json
           variables: |
             relayerId=${{ matrix.relayer_id }}
-            awsAccountId=${{ env.AWS_STAGE }}
+            awsAccountId=${{ env.AWS_DEVNET }}
             awsRegion=${{ secrets.AWS_REGION_3 }}
             awsEfs=${{ secrets.DEVNET_EFS_3 }}
 
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_STAGE }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
+          role-to-assume: arn:aws:iam::${{ env.AWS_DEVNET }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
           aws-region: ${{ secrets.AWS_REGION_3 }}
           role-session-name: GithubActions
 

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -7,6 +7,8 @@ on:
   release:
     types:
       - published
+
+run-name: Deploy Relayers to Testnet - ${{ inputs.release_tag }} by @${{ github.actor }}
       
 env:
   ENVIRONMENT: 'TESTNET'

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -12,13 +12,11 @@ env:
   ENVIRONMENT: 'TESTNET'
   REGISTRY: 'ghcr.io'
   TAG: 'stable'
-  AWS_TESTNET: '${{ secrets.AWS_ARN }}'
 
 jobs:
   push:
     name: push
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       id-token: write
@@ -60,10 +58,12 @@ jobs:
     needs: push
     name: deploy
     runs-on: ubuntu-latest
+    environment: testnet
     strategy:
       matrix:
         relayer_id: [0, 1]
-
+    env:
+      AWS_TESTNET: '${{ secrets.AWS_TESTNET }}'
     permissions:
       contents: read
       id-token: write
@@ -84,7 +84,7 @@ jobs:
           variables: |
             relayerId=${{ matrix.relayer_id }}
             awsAccountId=${{ env.AWS_TESTNET }}
-            awsRegion=${{ secrets.AWS_REGION }}
+            awsRegion=${{ secrets.AWS_REGION_1 }}
             awsEfs=${{ secrets.TESTNET_EFS_1 }}
             imageTag=${{ github.ref_name }}
 
@@ -92,7 +92,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_TESTNET }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION_1 }}
           role-session-name: GithubActions
 
       - name: deploy task definition
@@ -112,17 +112,17 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
         if: always()
 
-          ######################## region 2 ########################
-
           ######################## region 3 ########################
   deploy_reg_3:
     needs: push
     name: deploy region 3
     runs-on: ubuntu-latest
+    environment: testnet
     strategy:
       matrix:
         relayer_id: [2]
-
+    env:
+      AWS_TESTNET: '${{ secrets.AWS_TESTNET }}'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Access GitHub Secrets according to the environments

## Description
GitHub Actions workflows should access secrets based on the environments

## Related Issue Or Context


Related: #[528](https://github.com/sygmaprotocol/devops/issues/528)

## How Has This Been Tested? Testing details.
Tested on Sprinter

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
