### PR TITLE
feat: match configs by domainID

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -76,7 +76,7 @@ func Run() error {
 	configFlag := viper.GetString(config.ConfigFlagName)
 	configURL := viper.GetString("config-url")
 
-	configuration := &config.Config{}
+	var configuration *config.Config
 	if configURL != "" {
 		configuration, err = config.GetSharedConfigFromNetwork(configURL, configuration)
 		panicOnError(err)

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,12 @@ func processRawConfig(rawConfig RawConfig, config *Config) (*Config, error) {
 	if err != nil {
 		return config, err
 	}
+	if config == nil {
+		config := &Config{}
+		config.RelayerConfig = relayerConfig
+		config.ChainConfigs = rawConfig.ChainConfigs
+		return config, nil
+	}
 
 	chainConfigs := make([]map[string]interface{}, 0)
 	for i, chain := range rawConfig.ChainConfigs {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -74,11 +74,130 @@ func (s *GetConfigTestSuite) Test_GetConfigFromENV() {
 
 	// load from Env
 	cnf, err := config.GetConfigFromENV(&config.Config{ChainConfigs: []map[string]interface{}{{
+		"id":                 1,
 		"blockConfirmations": 5,
 		"gasLimit":           500,
 	}, {
+		"id":                 2,
 		"blockConfirmations": 3,
 		"gasLimit":           300,
+	}}})
+
+	s.Nil(err)
+
+	s.Equal(config.Config{
+		RelayerConfig: relayer.RelayerConfig{
+			LogLevel:   1,
+			LogFile:    "out.log",
+			Env:        "TEST",
+			Id:         "123",
+			HealthPort: 9001,
+			MpcConfig: relayer.MpcRelayerConfig{
+				TopologyConfiguration: relayer.TopologyConfiguration{
+					EncryptionKey: "test-enc-key",
+					Url:           "http://test.com",
+					Path:          "path",
+				},
+				Port:                    9000,
+				KeysharePath:            "/cfg/keyshares/0.keyshare",
+				FrostKeysharePath:       "/cfg/keyshares/0-frost.keyshare",
+				Key:                     "test-pk",
+				CommHealthCheckInterval: 5 * time.Minute,
+			},
+			BullyConfig: relayer.BullyConfig{
+				PingWaitTime:     1 * time.Second,
+				PingBackOff:      1 * time.Second,
+				PingInterval:     1 * time.Second,
+				ElectionWaitTime: 2 * time.Second,
+				BullyWaitTime:    3 * time.Minute,
+			},
+			UploaderConfig: relayer.UploaderConfig{
+				MaxRetries:     5,
+				MaxElapsedTime: 300000,
+			},
+		},
+		ChainConfigs: []map[string]interface{}{
+			{
+				"id":                 float64(1),
+				"type":               "evm",
+				"bridge":             "0xd606A00c1A39dA53EA7Bb3Ab570BBE40b156EB66",
+				"erc721Handler":      "0x75dF75bcdCa8eA2360c562b4aaDBAF3dfAf5b19b",
+				"gasLimit":           500,
+				"maxGasPrice":        2e+10,
+				"from":               "0xff93B45308FD417dF303D6515aB04D9e89a750Ca",
+				"name":               "evm1",
+				"endpoint":           "ws://evm1-1:8546",
+				"erc20Handler":       "0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e",
+				"genericHandler":     "0xe1588E2c6a002AE93AeD325A910Ed30961874109",
+				"blockConfirmations": float64(2),
+			},
+			{
+				"id":                 float64(2),
+				"type":               "evm",
+				"bridge":             "0xd606A00c1A39dA53EA7Bb3Ab570BBE40b156EB66",
+				"erc721Handler":      "0x75dF75bcdCa8eA2360c562b4aaDBAF3dfAf5b19b",
+				"gasLimit":           300,
+				"maxGasPrice":        2e+10,
+				"from":               "0xff93B45308FD417dF303D6515aB04D9e89a750Ca",
+				"name":               "evm2",
+				"endpoint":           "ws://evm2-1:8546",
+				"erc20Handler":       "0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e",
+				"genericHandler":     "0xe1588E2c6a002AE93AeD325A910Ed30961874109",
+				"blockConfirmations": float64(2),
+			},
+		},
+	}, *cnf)
+}
+
+func (s *GetConfigTestSuite) Test_GetConfigFromENV_RandomOrder() {
+	_ = os.Setenv("SYG_CHAINS", `[
+   {
+      "id":1,
+      "from":"0xff93B45308FD417dF303D6515aB04D9e89a750Ca",
+      "name":"evm1",
+      "type":"evm",
+      "endpoint":"ws://evm1-1:8546",
+      "bridge":"0xd606A00c1A39dA53EA7Bb3Ab570BBE40b156EB66",
+      "erc20Handler":"0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e",
+      "erc721Handler":"0x75dF75bcdCa8eA2360c562b4aaDBAF3dfAf5b19b",
+      "genericHandler":"0xe1588E2c6a002AE93AeD325A910Ed30961874109",
+      "maxGasPrice":20000000000,
+      "blockConfirmations":2
+   },
+	 {
+   "id":2,
+   "from":"0xff93B45308FD417dF303D6515aB04D9e89a750Ca",
+   "name":"evm2",
+   "type":"evm",
+   "endpoint":"ws://evm2-1:8546",
+   "bridge":"0xd606A00c1A39dA53EA7Bb3Ab570BBE40b156EB66",
+   "erc20Handler":"0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e",
+   "erc721Handler":"0x75dF75bcdCa8eA2360c562b4aaDBAF3dfAf5b19b",
+   "genericHandler":"0xe1588E2c6a002AE93AeD325A910Ed30961874109",
+   "maxGasPrice":20000000000,
+   "blockConfirmations":2
+}
+]`)
+
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_KEY", "test-pk")
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_KEYSHAREPATH", "/cfg/keyshares/0.keyshare")
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_FROSTKEYSHAREPATH", "/cfg/keyshares/0-frost.keyshare")
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_PORT", "9000")
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_ENCRYPTIONKEY", "test-enc-key")
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_URL", "http://test.com")
+	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH", "path")
+	_ = os.Setenv("SYG_RELAYER_ENV", "TEST")
+	_ = os.Setenv("SYG_RELAYER_ID", "123")
+
+	// load from Env
+	cnf, err := config.GetConfigFromENV(&config.Config{ChainConfigs: []map[string]interface{}{{
+		"id":                 2,
+		"blockConfirmations": 3,
+		"gasLimit":           300,
+	}, {
+		"id":                 1,
+		"blockConfirmations": 5,
+		"gasLimit":           500,
 	}}})
 
 	s.Nil(err)
@@ -186,71 +305,13 @@ func (s *GetConfigTestSuite) Test_SharedConfigLengthMismatch() {
 	_ = os.Setenv("SYG_RELAYER_MPCCONFIG_TOPOLOGYCONFIGURATION_PATH", "path")
 
 	// load from Env
-	cnf, err := config.GetConfigFromENV(&config.Config{ChainConfigs: []map[string]interface{}{{
+	_, err := config.GetConfigFromENV(&config.Config{ChainConfigs: []map[string]interface{}{{
+		"id":                 1,
 		"blockConfirmations": 5,
 		"gasLimit":           500,
 	}}})
 
-	s.Nil(err)
-
-	s.Equal(config.Config{
-		RelayerConfig: relayer.RelayerConfig{
-			LogLevel:   1,
-			LogFile:    "out.log",
-			HealthPort: 9001,
-			MpcConfig: relayer.MpcRelayerConfig{
-				TopologyConfiguration: relayer.TopologyConfiguration{
-					EncryptionKey: "test-enc-key",
-					Url:           "http://test.com",
-					Path:          "path",
-				},
-				Port:                    9000,
-				KeysharePath:            "/cfg/keyshares/0.keyshare",
-				Key:                     "test-pk",
-				CommHealthCheckInterval: 5 * time.Minute,
-			},
-			BullyConfig: relayer.BullyConfig{
-				PingWaitTime:     1 * time.Second,
-				PingBackOff:      1 * time.Second,
-				PingInterval:     1 * time.Second,
-				ElectionWaitTime: 2 * time.Second,
-				BullyWaitTime:    3 * time.Minute,
-			},
-			UploaderConfig: relayer.UploaderConfig{
-				MaxRetries:     5,
-				MaxElapsedTime: 300000,
-			},
-		},
-		ChainConfigs: []map[string]interface{}{
-			{
-				"id":                 float64(1),
-				"type":               "evm",
-				"bridge":             "0xd606A00c1A39dA53EA7Bb3Ab570BBE40b156EB66",
-				"erc721Handler":      "0x75dF75bcdCa8eA2360c562b4aaDBAF3dfAf5b19b",
-				"gasLimit":           500,
-				"maxGasPrice":        2e+10,
-				"from":               "0xff93B45308FD417dF303D6515aB04D9e89a750Ca",
-				"name":               "evm1",
-				"endpoint":           "ws://evm1-1:8546",
-				"erc20Handler":       "0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e",
-				"genericHandler":     "0xe1588E2c6a002AE93AeD325A910Ed30961874109",
-				"blockConfirmations": float64(2),
-			},
-			{
-				"id":                 float64(2),
-				"type":               "evm",
-				"bridge":             "0xd606A00c1A39dA53EA7Bb3Ab570BBE40b156EB66",
-				"erc721Handler":      "0x75dF75bcdCa8eA2360c562b4aaDBAF3dfAf5b19b",
-				"maxGasPrice":        2e+10,
-				"from":               "0xff93B45308FD417dF303D6515aB04D9e89a750Ca",
-				"name":               "evm2",
-				"endpoint":           "ws://evm2-1:8546",
-				"erc20Handler":       "0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e",
-				"genericHandler":     "0xe1588E2c6a002AE93AeD325A910Ed30961874109",
-				"blockConfirmations": float64(2),
-			},
-		},
-	}, *cnf)
+	s.NotNil(err)
 }
 
 type ConfigTestCase struct {
@@ -267,6 +328,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 			name: "missing chain type",
 			inConfig: config.RawConfig{
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"name": "chain1",
 				}},
 				RelayerConfig: relayer.RawRelayerConfig{
@@ -319,6 +381,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "chain1",
 				}},
@@ -354,6 +417,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "chain1",
 				}},
@@ -380,6 +444,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 				},
 
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "chain1",
 				}},
@@ -410,6 +475,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "evm1",
 				}},
@@ -446,6 +512,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "evm1",
 				}},
@@ -484,6 +551,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "evm1",
 				}},
@@ -522,6 +590,7 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 					},
 				},
 				ChainConfigs: []map[string]interface{}{{
+					"id":   float64(1),
 					"type": "evm",
 					"name": "evm1",
 				}},
@@ -534,7 +603,13 @@ func (s *GetConfigTestSuite) Test_GetConfigFromFile() {
 			file, _ := json.Marshal(t.inConfig)
 			_ = os.WriteFile("test.json", file, 0644)
 
-			conf, err := config.GetConfigFromFile("test.json", &config.Config{})
+			conf, err := config.GetConfigFromFile("test.json", &config.Config{
+				ChainConfigs: []map[string]interface{}{
+					{
+						"id": 1,
+					},
+				},
+			})
 
 			_ = os.Remove("test.json")
 

--- a/example/app/app.go
+++ b/example/app/app.go
@@ -67,8 +67,7 @@ import (
 )
 
 func Run() error {
-	configuration := &config.Config{}
-	configuration, err := config.GetConfigFromFile(viper.GetString(config.ConfigFlagName), configuration)
+	configuration, err := config.GetConfigFromFile(viper.GetString(config.ConfigFlagName), nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Match configs by domainID to prevent errors when the shared config and relayer config are mismatched. 

How it functions now:
  - relayer config is the source of truth
  - SYG_CHAINS from relayer is matched by domainID with the shared config ID
  - if the config in shared config is missing the relayer will throw an error
  - configs don't have to be ordered 

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #374 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
